### PR TITLE
feat: Configure GitHub Pages for documentation and reports

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.20.1'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests and generate reports
+        run: npm run report:all
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/doc/index.html
+++ b/doc/index.html
@@ -58,6 +58,10 @@
                     <span class="sidebar__icon">🎯</span>
                     Conclusão
                 </a></li>
+                <li><a href="../artifacts/reports/dashboard.html" class="sidebar__link">
+                    <span class="sidebar__icon">📊</span>
+                    Relatório de Testes
+                </a></li>
             </ul>
         </nav>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projeto de Testes Automatizados de API</title>
+    <style>
+        body { font-family: sans-serif; margin: 40px; background-color: #f4f4f4; color: #333; }
+        .container { max-width: 800px; margin: 0 auto; background-color: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { color: #333; text-align: center; }
+        p { line-height: 1.6; }
+        .links { margin-top: 30px; text-align: center; }
+        .links a {
+            display: inline-block;
+            margin: 0 15px;
+            padding: 12px 25px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            font-size: 16px;
+            transition: background-color 0.3s ease;
+        }
+        .links a:hover { background-color: #0056b3; }
+        footer { text-align: center; margin-top: 40px; font-size: 0.9em; color: #777; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Bem-vindo ao Projeto de Testes Automatizados de API</h1>
+        <p>Este projeto demonstra uma arquitetura para testes automatizados de API utilizando Newman e Swagger.</p>
+        <p>A documentação detalhada do projeto e o relatório de execução dos testes estão disponíveis nos links abaixo:</p>
+        <div class="links">
+            <a href="doc/index.html">Documentação do Projeto</a>
+            <a href="artifacts/reports/dashboard.html">Relatório de Testes</a>
+        </div>
+    </div>
+    <footer>
+        <p>Configurado para exibição via GitHub Pages.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Integrates project documentation and test reports into GitHub Pages.

Key changes:
- Modified the GitHub Actions workflow (`static.yml`) to:
    - Install Node.js and project dependencies.
    - Execute tests and generate reports (HTML and dashboard) using `npm run report:all` prior to deployment. This ensures the reports on GitHub Pages are always up-to-date.
- Created a new root `index.html` to act as the main landing page for the GitHub Pages site. This page provides clear navigation to the documentation and the main test report.
- Added a direct link to the test report (`artifacts/reports/dashboard.html`) within the sidebar navigation of the main documentation page (`doc/index.html`) for easier access.

This allows you to view both the project's detailed documentation and the latest test execution reports directly via GitHub Pages.

